### PR TITLE
Clarify password vars in all file

### DIFF
--- a/inventory/group_vars/all
+++ b/inventory/group_vars/all
@@ -1,7 +1,9 @@
 ---
 ironic_url: "http://localhost:6385/"
 network_interface: "virbr0"
+# ironic_db_password ironic user password for rabbit
 ironic_db_password: aSecretPassword473z
+# mysql_password: mysql root user password
 mysql_password:
 # If testing is true, then the environment is setup for using libvirt
 # virtual machines for the hardware instead of real hardware.

--- a/roles/ironic-install/templates/ironic.conf.j2
+++ b/roles/ironic-install/templates/ironic.conf.j2
@@ -634,7 +634,7 @@ node_locked_retry_interval=1
 # (eg, Nova) have been updated to accommodate the additional
 # time for deletion. (boolean value)
 #clean_nodes=false
-{% if cleaning %}
+{% if cleaning and not testing %}
 clean_nodes=true
 {% endif %}
 


### PR DESCRIPTION
This patch adds comment lines to clarify the difference between ironic_db_password
and mysql_password in the inventory/group_vars/all file.